### PR TITLE
change jenkins version on lts-jdk11

### DIFF
--- a/dockers/compose/docker-compose.yml
+++ b/dockers/compose/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
 
   jenkins:
-    image: jenkins/jenkins:2.255
+    image: jenkins/jenkins:lts-jdk11
     ports:
     - "127.0.0.1:9080:8080"
     volumes:


### PR DESCRIPTION
Current `jenkins` version in `docker-compose.yml` leads to errors while installing default plugins, most of them require a higher jenkins version. Before seeing this error attempted running `docker-compose up` multiple times, fixing this would save a lot of time for others.

<img width="501" alt="Screenshot 2021-12-28 at 11 50 26" src="https://user-images.githubusercontent.com/26203362/147568188-b6ef63df-6103-4637-bb12-7990edd91202.png">
